### PR TITLE
fix: setting profile page container width to 100% to better support small screens

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -57,5 +57,5 @@ body {
 }
 
 .user-info {
-  min-width: 800px;
+  width: 100%;
 }


### PR DESCRIPTION
# Description

This fix modifies user-profile in custom.css file and sets width to 100% instead of minimum 800 px.
This fixes an issue on small screens (such as mobile devices) on which the profile header renderred outside of the screen,
